### PR TITLE
Do not pin exact BLAS version in Conda recipe

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,21 +14,21 @@ environment:
     - job_name: osx-conda
       BUILD_SYS: conda
       APPVEYOR_BUILD_WORKER_IMAGE: macos-mojave
-    - job_name: osx-cibw
-      BUILD_SYS: cibuildwheel
-      ACCELERATE: 1
-      APPVEYOR_BUILD_WORKER_IMAGE: macos-mojave
     - job_name: linux-conda
       BUILD_SYS: conda
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
-    - job_name: linux-cibw-x86_64
-      BUILD_SYS: cibuildwheel
-      CIBW_ARCHS_LINUX: x86_64
-      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
-    - job_name: linux-cibw-i686
-      BUILD_SYS: cibuildwheel
-      CIBW_ARCHS_LINUX: i686
-      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
+    # - job_name: osx-cibw
+    #   BUILD_SYS: cibuildwheel
+    #   ACCELERATE: 1
+    #   APPVEYOR_BUILD_WORKER_IMAGE: macos-mojave
+    # - job_name: linux-cibw-x86_64
+    #   BUILD_SYS: cibuildwheel
+    #   CIBW_ARCHS_LINUX: x86_64
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
+    # - job_name: linux-cibw-i686
+    #   BUILD_SYS: cibuildwheel
+    #   CIBW_ARCHS_LINUX: i686
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
 
 stack: python 3.8
 
@@ -42,6 +42,7 @@ init:
       {
         Update-AppveyorBuild -Version "$($env:APPVEYOR_REPO_TAG_NAME.TrimStart("v"))"
       }
+  - ps: $env:APPVEYOR_REPO_TAG_NAME = "v0."
   - sh: export DIST=dist-${APPVEYOR_JOB_NAME}
   - cmd: set DIST=dist-%APPVEYOR_JOB_NAME%
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,18 +17,18 @@ environment:
     - job_name: linux-conda
       BUILD_SYS: conda
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
-    # - job_name: osx-cibw
-    #   BUILD_SYS: cibuildwheel
-    #   ACCELERATE: 1
-    #   APPVEYOR_BUILD_WORKER_IMAGE: macos-mojave
-    # - job_name: linux-cibw-x86_64
-    #   BUILD_SYS: cibuildwheel
-    #   CIBW_ARCHS_LINUX: x86_64
-    #   APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
-    # - job_name: linux-cibw-i686
-    #   BUILD_SYS: cibuildwheel
-    #   CIBW_ARCHS_LINUX: i686
-    #   APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
+    - job_name: osx-cibw
+      BUILD_SYS: cibuildwheel
+      ACCELERATE: 1
+      APPVEYOR_BUILD_WORKER_IMAGE: macos-mojave
+    - job_name: linux-cibw-x86_64
+      BUILD_SYS: cibuildwheel
+      CIBW_ARCHS_LINUX: x86_64
+      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
+    - job_name: linux-cibw-i686
+      BUILD_SYS: cibuildwheel
+      CIBW_ARCHS_LINUX: i686
+      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
 
 stack: python 3.8
 
@@ -42,7 +42,6 @@ init:
       {
         Update-AppveyorBuild -Version "$($env:APPVEYOR_REPO_TAG_NAME.TrimStart("v"))"
       }
-  - ps: $env:APPVEYOR_REPO_TAG_NAME = "v0.6.0"
   - sh: export DIST=dist-${APPVEYOR_JOB_NAME}
   - cmd: set DIST=dist-%APPVEYOR_JOB_NAME%
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -42,7 +42,7 @@ init:
       {
         Update-AppveyorBuild -Version "$($env:APPVEYOR_REPO_TAG_NAME.TrimStart("v"))"
       }
-  - ps: $env:APPVEYOR_REPO_TAG_NAME = "v0."
+  - ps: $env:APPVEYOR_REPO_TAG_NAME = "v0.6.0"
   - sh: export DIST=dist-${APPVEYOR_JOB_NAME}
   - cmd: set DIST=dist-%APPVEYOR_JOB_NAME%
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,6 +18,15 @@ elif [ $blas_impl = "accelerate" ]; then
   export ACCELERATE=1
 elif [ $blas_impl = "openblas" ]; then
   export OPENBLASROOT="${PREFIX}"
+  if [ ! -f "${PREFIX}/include/lapack.h" ]; then
+    # issue with some openblas-devel versions. Shove the copy we downloaded
+    # from the repo into our includes
+    # Ideally we have some checksum in here, but I'm not sure if we're
+    # guaranteed it
+    wget "https://raw.githubusercontent.com/xianyi/OpenBLAS/v0.3.13/lapack-netlib/LAPACKE/include/lapack.h"
+    mv "lapack.h" "${PREFIX}/include/lapack.h"
+    trap "rm -f '${PREFIX}/include/lapack.h'" EXIT
+  fi
 else
   1>&2 echo Unknown blas_impl
   exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,20 +36,22 @@ requirements:
     - python
     - numpy 1.11.3                        # [ py < 39 and not osx ]
     - numpy 1.16.6                        # [ py >= 39 or osx ]
-    # FIXME(sdrobert): openblas-devel headers > 0.3.6 are messed up
-    - openblas-devel 0.3.6                # [ blas_impl == 'openblas' ]
-    - mkl-devel                           # [ blas_impl == 'mkl' ]
+    - openblas-devel 0.2.20               # [ blas_impl == 'openblas' ]
+    - mkl-devel 2017                      # [ blas_impl == 'mkl' ]
     - setuptools
     - setuptools_scm
     - swig 4.0.2
   build:
     - {{ compiler('cxx') }}
   run:
-    # *-devel packages provide library packages as run_exports
     - python
     # there have been no major changes in the numpy api since 1.11.3 (currently
     # at 1.13). We'll see how long this lasts us
     - {{ pin_compatible('numpy', min_pin='x.x') }}
+    # we only need basic BLAS routines, which should be available in all
+    # versions
+    - mkl >=2017                            # [blas_impl == 'mkl']
+    - libopenblas >=0.2.20                  # [blas_impl == 'openblas']
   # new namespace package style does not play nicely with old style
   run_constrained:
     - pydrobert-param >0.2.0
@@ -59,9 +61,14 @@ requirements:
 build:
   number: {{ build_num }}
   detect_binary_files_with_prefix: False
-  skip: True  # [(blas_impl == 'openblas' and win) or py2k]
+  skip: True                              # [(blas_impl == 'openblas' and win) or py2k]
   force_use_keys:
     - python
+  ignore_run_exports:
+    # run_exports from *-devel pin the major.minor version. We use very basic
+    #
+    - mkl
+    - libopenblas
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,11 +36,15 @@ requirements:
     - python
     - numpy 1.11.3                        # [ py < 39 and not osx ]
     - numpy 1.16.6                        # [ py >= 39 or osx ]
-    - openblas-devel 0.2.20               # [ blas_impl == 'openblas' ]
-    - mkl-devel 2017                      # [ blas_impl == 'mkl' ]
+    # Numpy gets compiled to only a few versions of openblas. We'll choose
+    # whichever's easiest to resolve. We're only using basic BLAS functionality
+    # which should be available in all versions of the library, so we'll muck
+    # around with the version requirements below
+    - {{ blas_impl }}-devel
     - setuptools
     - setuptools_scm
     - swig 4.0.2
+    - wget
   build:
     - {{ compiler('cxx') }}
   run:
@@ -48,8 +52,6 @@ requirements:
     # there have been no major changes in the numpy api since 1.11.3 (currently
     # at 1.13). We'll see how long this lasts us
     - {{ pin_compatible('numpy', min_pin='x.x') }}
-    # we only need basic BLAS routines, which should be available in all
-    # versions
     - mkl >=2017                            # [blas_impl == 'mkl']
     - libopenblas >=0.2.20                  # [blas_impl == 'openblas']
   # new namespace package style does not play nicely with old style
@@ -65,8 +67,8 @@ build:
   force_use_keys:
     - python
   ignore_run_exports:
-    # run_exports from *-devel pin the major.minor version. We use very basic
-    #
+    # run_exports from *-devel pin the major.minor version. See above for why
+    # we ignore these
     - mkl
     - libopenblas
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,11 +40,12 @@ requirements:
     # whichever's easiest to resolve. We're only using basic BLAS functionality
     # which should be available in all versions of the library, so we'll muck
     # around with the version requirements below
-    - {{ blas_impl }}-devel
+    - openblas-devel                      # [ blas_impl == 'openblas' ]
+    - mkl-devel                           # [ blas_impl == 'mkl' ]
     - setuptools
     - setuptools_scm
     - swig 4.0.2
-    - wget  # [ blas_impl == 'openblas' ]
+    - wget                                # [ blas_impl == 'openblas' ]
   build:
     - {{ compiler('cxx') }}
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ requirements:
     - setuptools
     - setuptools_scm
     - swig 4.0.2
-    - wget
+    - wget  # [ blas_impl == 'openblas' ]
   build:
     - {{ compiler('cxx') }}
   run:


### PR DESCRIPTION
This PR updates the conda recipe to keep it from pinning the exact version of the underlying BLAS libraries. This will make them play nicer with other packages. Functionality hasn't changed.