### PR TITLE
Fix LAPACKEROOT linkage, no BLAS is default. Use pyproject.toml.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,8 +3,8 @@ version: build.{build}.branch.{branch}
 environment:
   CIBW_TEST_REQUIRES: pytest
   CIBW_TEST_COMMAND: pytest {project}/tests -m "not pytorch"
-  CIBW_ENVIRONMENT_MACOS: ACCELERATE=1
-  CIBW_ENVIRONMENT_WINDOWS: OPENBLASROOT=C:\\Libraries\\openblas
+  # CIBW_ENVIRONMENT_MACOS: ACCELERATE=1
+  # CIBW_ENVIRONMENT_WINDOWS: OPENBLASROOT=C:\\Libraries\\openblas
   CIBW_BEFORE_ALL_LINUX: bash {project}/recipe/cibw_before_all_linux.sh
   CIBW_BEFORE_ALL_MACOS: bash {project}/recipe/cibw_before_all_osx.sh
   CIBW_BEFORE_ALL_WINDOWS: powershell.exe {project}/recipe/cibw_before_all_win.ps1
@@ -21,12 +21,12 @@ environment:
     - job_name: manylinux-x86_64
       CIBW_ARCHS_LINUX: x86_64
       CIBW_SKIP: pp* *-musllinux*
-      CIBW_ENVIRONMENT_LINUX: OPENBLASROOT=/usr
+      # CIBW_ENVIRONMENT_LINUX: OPENBLASROOT=/usr
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
     - job_name: manylinux-i686
       CIBW_ARCHS_LINUX: i686
       CIBW_SKIP: pp* *-musllinux*
-      CIBW_ENVIRONMENT_LINUX: ATLASROOT=/usr
+      # CIBW_ENVIRONMENT_LINUX: ATLASROOT=/usr
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
     # FIXME(sdrobert): These work last I checked, but time out. Numpy currently
     # isn't building musllinux wheels
@@ -73,8 +73,8 @@ init:
 
 build: script
 
-cache:
-  - C:\Libraries\openblas -> recipe\cibw_before_build_win.ps1
+# cache:
+#   - C:\Libraries\openblas -> recipe\cibw_before_build_win.ps1
 
 install:
   - python -m pip install cibuildwheel

--- a/.gitignore
+++ b/.gitignore
@@ -73,4 +73,4 @@ venv/
 .ftpconfig
 .python-version
 .vscode/
-version.py
+_version.py

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,19 +1,16 @@
 HEAD
 ----
 
-- manylinux i686 wheel now links to
-  `ATLAS <http://math-atlas.sourceforge.net/>`__ instead of OpenBLAS because
-  the latter can no longer be installed with ``yum install openblas-devel`` on
-  CentOS 7 i686.
+- Cut Python less than 3.7, added up to 3.10
+- "No BLAS" is now the default build. None of the currently wrapped
+  functionality actually uses BLAS right now. 
 - Removed `KaldiLocaleWarning` and added a documentation page addressing
   locales.
 - Updated documentation, including a special page for the CLI.
-- Updated CI to only use
-  `cibuildwheel <https://github.com/pypa/cibuildwheel/>`__. Able to compile
-  Win-64 wheels. Link to `OpenBLAS <https://www.openblas.net/>`__ and
-  `Flang <https://github.com/flang-compiler/flang>`__.
+- Updated CI to only use `cibuildwheel
+  <https://github.com/pypa/cibuildwheel/>`__. Able to compile Win-64 wheels.
 - Updated Kaldi source.
-- Fixed ``setup.py``.
+- All but extension is now in ``setup.cfg`` and ``pyproject.toml``.
 - Got rid of Conda recipe. Will switch to
   `conda-forge <https://conda-forge.org/>`__.
 
@@ -39,7 +36,7 @@ Miscellaneous other changes include:
 - Updated numpy swig bindings for numpy 1.11.3
 - Black-formatted remaining source
 - Removed ``future`` and `six`, `configparser`
-- Shifted a lot of the configuration to `setup.cfg`. There is still
+- Shifted a lot of the configuration to ``setup.cfg``. There is still
   considerable work in ``setup.py`` due to the C extension
 - Shifted documentation source from ``doc/`` to ``docs/``
 - Shuffled around the indexing of documentation

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,0 @@
-include swig/pydrobert/kaldi_wrap.cpp
-exclude .gitignore appveyor.yml
-prune recipe

--- a/README.rst
+++ b/README.rst
@@ -126,19 +126,13 @@ To install via ``pip``::
 
    pip install pydrobert-kaldi
 
-You can also try building from source, but you'll have to specify where your
-BLAS install is somehow::
+You can also try building from source. To do so, you'll need to first install
+`SWIG 4.0 <https://www.swig.org/>`__ and an appropriate C++ compiler, then
 
-   # for OpenBLAS
-   OPENBLASROOT=/path/to/openblas/install pip install \
-     git+https://github.com/sdrobert/pydrobert-kaldi.git
-   # for MKL
-   MKLROOT=/path/to/mkl/install pip install \
-     git+https://github.com/sdrobert/pydrobert-kaldi.git
-   # for Accelerate (OSX only)
-   ACCELERATE=1 pip install \
-     git+https://github.com/sdrobert/pydrobert-kaldi.git
-   # see setup.py for more options
+   pip install git+https://github.com/sdrobert/pydrobert-kaldi.git
+
+The current version does not require a BLAS install, though it likely will
+in the future as more is wrapped.
 
 License
 -------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
+requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2", "oldest-supported-numpy"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "src/pydrobert/kaldi/_version.py"

--- a/recipe/cibw_before_all_linux.sh
+++ b/recipe/cibw_before_all_linux.sh
@@ -39,7 +39,7 @@ fi
 if [ ! -z "${OPENBLASROOT}" ]; then
   if [ ! -f "${OPENBLASROOT}/include/cblas.h" ] ; then
     $install_command $openblas_pkg
-    find "${OPENBLASROOT}" \( -name 'cblas.h' -o -name 'lapack.h' -o -name 'libopenblas.so' \)
+    find "${OPENBLASROOT}" \( -name 'cblas.h' -o -name 'lapacke.h' -o -name 'libopenblas.so' \)
   fi
 fi
 if [ ! -z "${ATLASROOT}" ]; then

--- a/recipe/cibw_before_all_linux.sh
+++ b/recipe/cibw_before_all_linux.sh
@@ -2,7 +2,6 @@
 
 set -e -x
 
-if false; then
 if command -v yum &> /dev/null; then
   install_command="yum install -y"
   openblas_pkg=openblas-devel

--- a/recipe/cibw_before_all_linux.sh
+++ b/recipe/cibw_before_all_linux.sh
@@ -39,7 +39,7 @@ fi
 if [ ! -z "${OPENBLASROOT}" ]; then
   if [ ! -f "${OPENBLASROOT}/include/cblas.h" ] ; then
     $install_command $openblas_pkg
-    find "${OPENBLASROOT}" \( -name 'cblas.h' -o -name 'lapacke.h' -o -name 'libopenblas.so' \)
+    find "${OPENBLASROOT}" \( -name 'cblas.h' -o -name 'lapack.h' -o -name 'libopenblas.so' \)
   fi
 fi
 if [ ! -z "${ATLASROOT}" ]; then

--- a/recipe/cibw_before_all_linux.sh
+++ b/recipe/cibw_before_all_linux.sh
@@ -2,6 +2,7 @@
 
 set -e -x
 
+if false; then
 if command -v yum &> /dev/null; then
   install_command="yum install -y"
   openblas_pkg=openblas-devel

--- a/recipe/cibw_before_all_win.ps1
+++ b/recipe/cibw_before_all_win.ps1
@@ -9,28 +9,29 @@ if ($null -eq $swigexe) {
 }
 
 # openblas
-New-Item -Path $env:OPENBLASROOT -ItemType "directory" -ErrorAction "ignore"
-$openblaslib = Get-ChildItem -Path $env:OPENBLASROOT -Recurse -Filter "openblas.lib" -ErrorAction "ignore"
-$cblash = Get-ChildItem -Path $env:OPENBLASROOT -Recurse -Filter "cblas.h" -ErrorAction "ignore"
-$lapackeh = Get-ChildItem -Path $env:OPENBLASROOT -Recurse -Filter "lapacke.h" -ErrorAction "ignore"
+if (-not ([string]::IsNullOrEmpty($env:OPENBLASROOT))) {
+  New-Item -Path $env:OPENBLASROOT -ItemType "directory" -ErrorAction "ignore"
+  $openblaslib = Get-ChildItem -Path $env:OPENBLASROOT -Recurse -Filter "openblas.lib" -ErrorAction "ignore"
+  $cblash = Get-ChildItem -Path $env:OPENBLASROOT -Recurse -Filter "cblas.h" -ErrorAction "ignore"
+  $lapackeh = Get-ChildItem -Path $env:OPENBLASROOT -Recurse -Filter "lapacke.h" -ErrorAction "ignore"
 
-if (($null -eq $openblaslib) -or ($null -eq $cblash) -or ($null -eq $lapackeh)) {
-  Invoke-WebRequest -Uri "https://anaconda.org/conda-forge/openblas/0.2.20/download/win-64/openblas-0.2.20-vc14_8.tar.bz2" -OutFile "openblas.tar.bz2"
-  $hash = Get-FileHash openblas.tar.bz2
-  if (-not ($hash.Hash -eq "74BB55BCC4C5B760A08424ED7A53D08FF9581278BB05441F7F6E5F43AADCF8CA")) { Write-Error "openblas hash does not match" }
-  & 7z x openblas.tar.bz2
-  & 7z x -aoa openblas.tar
-  if (-not $?) { Write-Error "Unable to extract openblas" }
-  Invoke-WebRequest -Uri "https://anaconda.org/conda-forge/libflang/5.0.0/download/win-64/libflang-5.0.0-vc14_1.tar.bz2" -OutFile "libflang.tar.bz2"
-  $hash = Get-FileHash libflang.tar.bz2
-  if (-not ($hash.Hash -eq "BC50A67898F82820F5138938FBAABC90CF13495CE188E91725A33B6FAD25F06F")) { Write-Error "libflang hash does not match" }
-  & 7z x libflang.tar.bz2
-  & 7z x -aoa libflang.tar
-  if (-not $?) { Write-Error "Unable to extract libflang" }
-  Copy-Item -Path ".\Library\*" -Destination $env:OPENBLASROOT -Recurse
-  # check that they all exist
-  $openblaslib = Get-ChildItem -Path $env:OPENBLASROOT -Recurse -Filter "openblas.lib"
-  $cblash = Get-ChildItem -Path $env:OPENBLASROOT -Recurse -Filter "cblas.h"
-  $lapackeh = Get-ChildItem -Path $env:OPENBLASROOT -Recurse -Filter "lapacke.h"
+  if (($null -eq $openblaslib) -or ($null -eq $cblash) -or ($null -eq $lapackeh)) {
+    Invoke-WebRequest -Uri "https://anaconda.org/conda-forge/openblas/0.2.20/download/win-64/openblas-0.2.20-vc14_8.tar.bz2" -OutFile "openblas.tar.bz2"
+    $hash = Get-FileHash openblas.tar.bz2
+    if (-not ($hash.Hash -eq "74BB55BCC4C5B760A08424ED7A53D08FF9581278BB05441F7F6E5F43AADCF8CA")) { Write-Error "openblas hash does not match" }
+    & 7z x openblas.tar.bz2
+    & 7z x -aoa openblas.tar
+    if (-not $?) { Write-Error "Unable to extract openblas" }
+    Invoke-WebRequest -Uri "https://anaconda.org/conda-forge/libflang/5.0.0/download/win-64/libflang-5.0.0-vc14_1.tar.bz2" -OutFile "libflang.tar.bz2"
+    $hash = Get-FileHash libflang.tar.bz2
+    if (-not ($hash.Hash -eq "BC50A67898F82820F5138938FBAABC90CF13495CE188E91725A33B6FAD25F06F")) { Write-Error "libflang hash does not match" }
+    & 7z x libflang.tar.bz2
+    & 7z x -aoa libflang.tar
+    if (-not $?) { Write-Error "Unable to extract libflang" }
+    Copy-Item -Path ".\Library\*" -Destination $env:OPENBLASROOT -Recurse
+    # check that they all exist
+    $openblaslib = Get-ChildItem -Path $env:OPENBLASROOT -Recurse -Filter "openblas.lib"
+    $cblash = Get-ChildItem -Path $env:OPENBLASROOT -Recurse -Filter "cblas.h"
+    $lapackeh = Get-ChildItem -Path $env:OPENBLASROOT -Recurse -Filter "lapacke.h"
+  }
 }
-

--- a/recipe/cibw_before_all_win.ps1
+++ b/recipe/cibw_before_all_win.ps1
@@ -12,9 +12,9 @@ if ($null -eq $swigexe) {
 New-Item -Path $env:OPENBLASROOT -ItemType "directory" -ErrorAction "ignore"
 $openblaslib = Get-ChildItem -Path $env:OPENBLASROOT -Recurse -Filter "openblas.lib" -ErrorAction "ignore"
 $cblash = Get-ChildItem -Path $env:OPENBLASROOT -Recurse -Filter "cblas.h" -ErrorAction "ignore"
-$lapackeh = Get-ChildItem -Path $env:OPENBLASROOT -Recurse -Filter "lapacke.h" -ErrorAction "ignore"
+$lapackh = Get-ChildItem -Path $env:OPENBLASROOT -Recurse -Filter "lapack.h" -ErrorAction "ignore"
 
-if (($null -eq $openblaslib) -or ($null -eq $cblash) -or ($null -eq $lapackeh)) {
+if (($null -eq $openblaslib) -or ($null -eq $cblash) -or ($null -eq $lapackh)) {
   Invoke-WebRequest -Uri "https://anaconda.org/conda-forge/openblas/0.2.20/download/win-64/openblas-0.2.20-vc14_8.tar.bz2" -OutFile "openblas.tar.bz2"
   $hash = Get-FileHash openblas.tar.bz2
   if (-not ($hash.Hash -eq "74BB55BCC4C5B760A08424ED7A53D08FF9581278BB05441F7F6E5F43AADCF8CA")) { Write-Error "openblas hash does not match" }
@@ -31,6 +31,6 @@ if (($null -eq $openblaslib) -or ($null -eq $cblash) -or ($null -eq $lapackeh)) 
   # check that they all exist
   $openblaslib = Get-ChildItem -Path $env:OPENBLASROOT -Recurse -Filter "openblas.lib"
   $cblash = Get-ChildItem -Path $env:OPENBLASROOT -Recurse -Filter "cblas.h"
-  $lapackeh = Get-ChildItem -Path $env:OPENBLASROOT -Recurse -Filter "lapacke.h"
+  $lapackh = Get-ChildItem -Path $env:OPENBLASROOT -Recurse -Filter "lapack.h"
 }
 

--- a/recipe/cibw_before_all_win.ps1
+++ b/recipe/cibw_before_all_win.ps1
@@ -12,9 +12,9 @@ if ($null -eq $swigexe) {
 New-Item -Path $env:OPENBLASROOT -ItemType "directory" -ErrorAction "ignore"
 $openblaslib = Get-ChildItem -Path $env:OPENBLASROOT -Recurse -Filter "openblas.lib" -ErrorAction "ignore"
 $cblash = Get-ChildItem -Path $env:OPENBLASROOT -Recurse -Filter "cblas.h" -ErrorAction "ignore"
-$lapackh = Get-ChildItem -Path $env:OPENBLASROOT -Recurse -Filter "lapack.h" -ErrorAction "ignore"
+$lapackeh = Get-ChildItem -Path $env:OPENBLASROOT -Recurse -Filter "lapacke.h" -ErrorAction "ignore"
 
-if (($null -eq $openblaslib) -or ($null -eq $cblash) -or ($null -eq $lapackh)) {
+if (($null -eq $openblaslib) -or ($null -eq $cblash) -or ($null -eq $lapackeh)) {
   Invoke-WebRequest -Uri "https://anaconda.org/conda-forge/openblas/0.2.20/download/win-64/openblas-0.2.20-vc14_8.tar.bz2" -OutFile "openblas.tar.bz2"
   $hash = Get-FileHash openblas.tar.bz2
   if (-not ($hash.Hash -eq "74BB55BCC4C5B760A08424ED7A53D08FF9581278BB05441F7F6E5F43AADCF8CA")) { Write-Error "openblas hash does not match" }
@@ -31,6 +31,6 @@ if (($null -eq $openblaslib) -or ($null -eq $cblash) -or ($null -eq $lapackh)) {
   # check that they all exist
   $openblaslib = Get-ChildItem -Path $env:OPENBLASROOT -Recurse -Filter "openblas.lib"
   $cblash = Get-ChildItem -Path $env:OPENBLASROOT -Recurse -Filter "cblas.h"
-  $lapackh = Get-ChildItem -Path $env:OPENBLASROOT -Recurse -Filter "lapack.h"
+  $lapackeh = Get-ChildItem -Path $env:OPENBLASROOT -Recurse -Filter "lapacke.h"
 }
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,8 @@ description = "Swig bindings for Kaldi"
 long_description = file: README.rst
 long_description_content_type = text/x-rst
 license = Apache-2.0
-license_file = LICENSE
+license_files =
+  LICENSE
 url = https://github.com/sdrobert/pydrobert-kaldi
 project_urls =
   Documentation = https://pydrobert-kaldi.readthedocs.io
@@ -20,7 +21,7 @@ zip_safe = False
 packages = find_namespace:
 package_dir =
   = src
-python_requires = >= 3.6
+python_requires = >= 3.7
 install_requires =
   numpy>=1.11.3
 

--- a/setup.py
+++ b/setup.py
@@ -220,9 +220,10 @@ def atlas_setup(roots):
 
 
 def lapacke_setup(roots):
+    # only relies on the routines from lapack, so don't link to lapacke
     return blas_setup(
         roots,
-        ("blas", "cblas", "lapack", "lapacke"),
+        ("blas", "cblas", "lapack"),
         ("cblas.h", "lapacke.h"),
         {"DEFINES": [("HAVE_OPENBLAS", None)]},
     )

--- a/setup.py
+++ b/setup.py
@@ -245,6 +245,10 @@ def accelerate_setup():
     }
 
 
+def noblas_setup():
+    return {"DEFINES": [("HAVE_NOBLAS", None)]}
+
+
 PWD = path.abspath(path.dirname(__file__))
 PYTHON_DIR = path.join(PWD, "python")
 SRC_DIR = path.join(PWD, "src")
@@ -328,7 +332,7 @@ elif NUM_BLAS_OPTS:
     else:
         raise Exception("Accelerate is only available on OSX")
 else:
-    raise ValueError("No BLAS root specified!")
+    BLAS_DICT = noblas_setup()
 
 
 LIBRARIES += BLAS_DICT.get("BLAS_LIBRARIES", [])

--- a/setup.py
+++ b/setup.py
@@ -203,7 +203,7 @@ def openblas_setup(roots):
     return blas_setup(
         roots,
         ("openblas",),
-        ("cblas.h", "lapacke.h"),
+        ("cblas.h", "lapack.h"),
         {"DEFINES": [("HAVE_OPENBLAS", None)]},
     )
 
@@ -220,10 +220,12 @@ def atlas_setup(roots):
 
 
 def lapacke_setup(roots):
+    # XXX(sdrobert): kaldi only uses routines defined in lapack.h, so there's no need
+    # to link against lapacke
     return blas_setup(
         roots,
-        ("blas", "cblas", "lapack", "lapacke"),
-        ("cblas.h", "lapacke.h"),
+        ("blas", "cblas", "lapack"),
+        ("cblas.h", "lapack.h"),
         {"DEFINES": [("HAVE_OPENBLAS", None)]},
     )
 

--- a/setup.py
+++ b/setup.py
@@ -203,7 +203,7 @@ def openblas_setup(roots):
     return blas_setup(
         roots,
         ("openblas",),
-        ("cblas.h", "lapack.h"),
+        ("cblas.h", "lapacke.h"),
         {"DEFINES": [("HAVE_OPENBLAS", None)]},
     )
 
@@ -220,12 +220,10 @@ def atlas_setup(roots):
 
 
 def lapacke_setup(roots):
-    # XXX(sdrobert): kaldi only uses routines defined in lapack.h, so there's no need
-    # to link against lapacke
     return blas_setup(
         roots,
-        ("blas", "cblas", "lapack"),
-        ("cblas.h", "lapack.h"),
+        ("blas", "cblas", "lapack", "lapacke"),
+        ("cblas.h", "lapacke.h"),
         {"DEFINES": [("HAVE_OPENBLAS", None)]},
     )
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import platform
-from posixpath import basename
 import sys
 
 from distutils.spawn import find_executable
@@ -22,7 +21,6 @@ from os import path
 from os import walk
 from re import findall
 from setuptools import setup
-from setuptools.command.build_ext import build_ext
 from setuptools.extension import Extension
 
 IS_64_BIT = sys.maxsize > 2 ** 32
@@ -245,67 +243,6 @@ def accelerate_setup():
     }
 
 
-def custom_blas_setup(blas_includes, blas_libraries):
-    # blas includes must be a directory/directories. Blas libraries
-    # could be the library names or paths to the libraries themselves.
-    blas_includes = set(blas_includes)
-    for include_dir in blas_includes:
-        if not path.isdir(include_dir):
-            raise Exception(
-                'path "{}" in BLAS_INCLUDES is not a directory'.format(include_dir)
-            )
-    library_names = set()
-    library_dirs = set()
-    ldflags = set()
-    candidate_blas_types = set()
-    for blas_library in blas_libraries:
-        if path.isfile(blas_library):
-            library_name = path.basename(blas_library)
-            if ON_WINDOWS:
-                library_names.add(library_name.split(".")[0])
-            elif platform.system() == "Linux":
-                ldflags.add("-l:{}".format(library_name))
-            else:
-                library_names.add(library_name[3:].split("."))
-            library_dirs.add(path.abspath(path.dirname(blas_library)))
-        else:
-            library_name = blas_library
-            library_names.add(library_name)
-        for blas_type in ("atlas", "mkl", "openblas", "lapacke", "clapack"):
-            if blas_type in library_name:
-                candidate_blas_types.add(blas_type)
-    if not len(candidate_blas_types):
-        raise Exception(
-            "Could not determine appropriate BLAS type for libraries listed "
-            "in BLAS_LIBRARIES"
-        )
-    elif len(candidate_blas_types) != 1:
-        raise Exception(
-            "BLAS_LIBRARIES contains libraries that could refer to any "
-            "of {}".format(candidate_blas_types)
-        )
-    blas_type = candidate_blas_types.pop()
-    # we need to check if the requisite libraries are present in the
-    # inferred directories & get the appropriate defines. We then force
-    # *our* directories and libraries. Any problems with this should be
-    # caught at compile/link time
-    if blas_type == "atlas":
-        ret = atlas_setup(library_dirs | blas_includes)
-    elif blas_type == "mkl":
-        ret = mkl_setup(library_dirs | blas_includes)
-    elif blas_type == "openblas":
-        ret = openblas_setup(library_dirs | blas_includes)
-    elif blas_type == "lapacke":
-        ret = lapacke_setup(library_dirs | blas_includes)
-    else:
-        ret = clapack_setup(library_dirs | blas_includes)
-    ret["BLAS_LIBRARIES"] = list(library_names)
-    ret["BLAS_LIBRARY_DIRS"] = list(library_dirs)
-    ret["BLAS_INCLUDES"] = list(blas_includes)
-    ret["LD_FLAGS"] = ret.get("LD_FLAGS", []) + list(ldflags)
-    return ret
-
-
 PWD = path.abspath(path.dirname(__file__))
 PYTHON_DIR = path.join(PWD, "python")
 SRC_DIR = path.join(PWD, "src")
@@ -313,9 +250,12 @@ SWIG_DIR = path.join(PWD, "swig")
 DEFINES = [
     ("KALDI_DOUBLEPRECISION", environ.get("KALDI_DOUBLEPRECISION", "0")),
 ]
+LD_FLAGS = []
 if platform.system() != "Windows":
-    FLAGS = ["-std=c++11", "-m64" if IS_64_BIT else "-m32", "-msse", "-msse2"]
-    FLAGS += ["-fPIC"]
+    FLAGS = ["-std=c++11", "-m64" if IS_64_BIT else "-m32", "-msse", "-msse2", "-FPIC"]
+    if platform.system() == "Darwin":
+        FLAGS += ["-flax-vector-conversions", "-stdlib=libc++"]
+        LD_FLAGS += ["-stdlib=libc++"]
     DEFINES += [
         ("_GLIBCXX_USE_CXX11_ABI", "0"),
         ("HAVE_EXECINFO_H", "1"),
@@ -326,7 +266,6 @@ else:
     FLAGS = []
     LIBRARIES = []
     DEFINES += []
-LD_FLAGS = []
 
 # Adds additional libraries. Primarily for alpine libc (musllinux build),
 # which doesn't package execinfo by default.
@@ -338,8 +277,6 @@ ATLAS_ROOT = cmdline_split(environ.get("ATLASROOT", ""))
 CLAPACK_ROOT = cmdline_split(environ.get("CLAPACKROOT", ""))
 LAPACKE_ROOT = cmdline_split(environ.get("LAPACKEROOT", ""))
 USE_ACCELERATE = environ.get("ACCELERATE", None)
-BLAS_INCLUDES = cmdline_split(environ.get("BLAS_INCLUDES", ""))
-BLAS_LIBRARIES = cmdline_split(environ.get("BLAS_LIBRARIES", ""))
 NUM_BLAS_OPTS = sum(
     bool(x)
     for x in (
@@ -349,7 +286,6 @@ NUM_BLAS_OPTS = sum(
         USE_ACCELERATE,
         CLAPACK_ROOT,
         LAPACKE_ROOT,
-        BLAS_LIBRARIES,
     )
 )
 if NUM_BLAS_OPTS > 1:
@@ -361,12 +297,6 @@ elif NUM_BLAS_OPTS:
         BLAS_DICT = openblas_setup(OPENBLAS_ROOT)
     elif ATLAS_ROOT:
         BLAS_DICT = atlas_setup(ATLAS_ROOT)
-    elif BLAS_INCLUDES or BLAS_LIBRARIES:
-        if bool(BLAS_INCLUDES) != bool(BLAS_LIBRARIES):
-            raise Exception(
-                "Both BLAS_LIBRARIES and BLAS_INCLUDES must be set if one " "is set"
-            )
-        BLAS_DICT = custom_blas_setup(BLAS_INCLUDES, BLAS_LIBRARIES)
     elif CLAPACK_ROOT:
         BLAS_DICT = clapack_setup(CLAPACK_ROOT)
     elif LAPACKE_ROOT:
@@ -376,11 +306,7 @@ elif NUM_BLAS_OPTS:
     else:
         raise Exception("Accelerate is only available on OSX")
 else:
-    print(
-        "No BLAS library specified at command line. Will look via numpy. If "
-        "you have problems with linking, please specify BLAS via command line."
-    )
-    BLAS_DICT = dict()
+    raise ValueError("No BLAS root specified!")
 
 
 LIBRARIES += BLAS_DICT.get("BLAS_LIBRARIES", [])
@@ -389,10 +315,6 @@ INCLUDE_DIRS = BLAS_DICT.get("BLAS_INCLUDES", []) + [SRC_DIR]
 LD_FLAGS += BLAS_DICT.get("LD_FLAGS", [])
 DEFINES += BLAS_DICT.get("DEFINES", [])
 FLAGS += BLAS_DICT.get("FLAGS", [])
-
-if platform.system() == "Darwin":
-    FLAGS += ["-flax-vector-conversions", "-stdlib=libc++"]
-    LD_FLAGS += ["-stdlib=libc++"]
 
 SRC_FILES = []
 if find_executable("swig"):
@@ -412,12 +334,6 @@ else:
 for base_dir, _, files in walk(SRC_DIR):
     SRC_FILES += [path.join(base_dir, f) for f in files if f.endswith(".cc")]
 
-SETUP_REQUIRES = ["setuptools_scm"]
-try:
-    import numpy  # type: ignore
-except ImportError:
-    SETUP_REQUIRES.append("oldest-supported-numpy")
-
 KALDI_LIBRARY = Extension(
     "pydrobert.kaldi._internal",
     sources=SRC_FILES,
@@ -432,97 +348,6 @@ KALDI_LIBRARY = Extension(
 )
 
 
-# https://stackoverflow.com/questions/2379898/
-# make-distutils-look-for-numpy-header-files-in-the-correct-place
-class CustomBuildExtCommand(build_ext):
-    def look_for_blas(self):
-        """Look for blas libraries through numpy"""
-        injection_lookup = {
-            "BLAS_LIBRARIES": (KALDI_LIBRARY, "libraries"),
-            "BLAS_LIBRARY_DIRS": (KALDI_LIBRARY, "library_dirs"),
-            "BLAS_INCLUDES": (KALDI_LIBRARY, "include_dirs"),
-            "LD_FLAGS": (KALDI_LIBRARY, "extra_link_args"),
-            "DEFINES": (KALDI_LIBRARY, "define_macros"),
-            "libraries": (KALDI_LIBRARY, "libraries"),
-            "library_dirs": (KALDI_LIBRARY, "library_dirs"),
-            "include_dirs": (self, "include_dirs"),
-            "define_macros": (KALDI_LIBRARY, "define_macros"),
-            "extra_compile_args": (KALDI_LIBRARY, "extra_compile_args"),
-            "extra_link_args": (KALDI_LIBRARY, "extra_link_args"),
-        }
-        from numpy.distutils import system_info
-
-        found_blas = False
-        blas_to_check = [
-            ("mkl", "HAVE_MKL", mkl_setup),
-            ("openblas_lapack", "HAVE_OPENBLAS", openblas_setup),
-            ("atlas", "HAVE_ATLAS", atlas_setup),
-            # numpy only cares about lapack, not c wrappers. It uses
-            # f77blas, after all
-            ("blas_opt", "HAVE_LAPACKE", lapacke_setup),
-            ("blas_opt", "HAVE_CLAPACK", clapack_setup),
-        ]
-        if platform.system() == "Darwin":
-            blas_to_check.append(("accelerate", "HAVE_CLAPACK", accelerate_setup))
-        for info_name, define, setup_func in blas_to_check:
-            info = system_info.get_info(info_name)
-            if not info:
-                continue
-            if info_name == "accelerate":
-                # should be sufficient
-                for key, value in info.items():
-                    if key in injection_lookup:
-                        obj, attribute = injection_lookup[key]
-                        past_attr = getattr(obj, attribute)
-                        if past_attr is None:
-                            setattr(obj, attribute, value)
-                        else:
-                            setattr(obj, attribute, past_attr + value)
-                KALDI_LIBRARY.define_macros.append((define, None))
-                print("Using {}".format(info_name))
-                found_blas = True
-                break
-            elif "library_dirs" not in info:
-                continue
-            # otherwise we try setting up in the library dirs, then in the
-            # directories above them.
-            check_dirs = list(info["library_dirs"])
-            check_dirs += [path.abspath(path.join(x, "..")) for x in check_dirs]
-            check_dirs = list(info.get("include_dirs", [])) + check_dirs
-            try:
-                blas_dict = setup_func(check_dirs)
-            except Exception:
-                continue
-            for key, value in blas_dict.items():
-                obj, attribute = injection_lookup[key]
-                past_attr = getattr(obj, attribute)
-                if past_attr is None:
-                    setattr(obj, attribute, value)
-                else:
-                    setattr(obj, attribute, past_attr + value)
-            print("Using {}".format(info_name))
-            found_blas = True
-        if not found_blas:
-            if {"bdist_wheel", "build", "develop", "install"}.intersection(sys.argv):
-                raise Exception("Unable to find BLAS library via numpy")
-            else:
-                print(
-                    "Unable to find BLAS library, but we might not be building "
-                    "anything. Might run into an exception later"
-                )
-
-    def finalize_options(self):
-        build_ext.finalize_options(self)
-        import numpy
-
-        if not len(BLAS_DICT):
-            self.look_for_blas()
-        self.include_dirs.append(numpy.get_include())
-
-
 setup(
-    use_scm_version={"write_to": "src/pydrobert/kaldi/version.py"},
-    cmdclass={"build_ext": CustomBuildExtCommand},
-    setup_requires=SETUP_REQUIRES,
     ext_modules=[KALDI_LIBRARY],
 )

--- a/src/matrix/cblas-wrappers.h
+++ b/src/matrix/cblas-wrappers.h
@@ -3,6 +3,8 @@
 // Copyright 2012  Johns Hopkins University (author: Daniel Povey);
 //                 Haihua Xu; Wei Shi
 
+// Modified 2022 by Sean Robertson, listed.
+
 // See ../../COPYING for clarification regarding multiple authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -379,37 +381,37 @@ inline void mul_elements(
 }
 
 
-
-// add clapack here
 #if !defined(HAVE_ATLAS)
+// sdrobert: updated to include the LAPACK_ prefix, which is what is exposed
+// in lapack.h
 inline void clapack_Xtptri(KaldiBlasInt *num_rows, float *Mdata, KaldiBlasInt *result) {
-  stptri_(const_cast<char *>("U"), const_cast<char *>("N"), num_rows, Mdata, result);
+  LAPACK_stptri(const_cast<char *>("U"), const_cast<char *>("N"), num_rows, Mdata, result);
 }
 inline void clapack_Xtptri(KaldiBlasInt *num_rows, double *Mdata, KaldiBlasInt *result) {
-  dtptri_(const_cast<char *>("U"), const_cast<char *>("N"), num_rows, Mdata, result);
+  LAPACK_dtptri(const_cast<char *>("U"), const_cast<char *>("N"), num_rows, Mdata, result);
 }
 // 
 inline void clapack_Xgetrf2(KaldiBlasInt *num_rows, KaldiBlasInt *num_cols, 
                             float *Mdata, KaldiBlasInt *stride, KaldiBlasInt *pivot, 
                             KaldiBlasInt *result) {
-  sgetrf_(num_rows, num_cols, Mdata, stride, pivot, result);
+  LAPACK_sgetrf(num_rows, num_cols, Mdata, stride, pivot, result);
 }
 inline void clapack_Xgetrf2(KaldiBlasInt *num_rows, KaldiBlasInt *num_cols, 
                             double *Mdata, KaldiBlasInt *stride, KaldiBlasInt *pivot, 
                             KaldiBlasInt *result) {
-  dgetrf_(num_rows, num_cols, Mdata, stride, pivot, result);
+  LAPACK_dgetrf(num_rows, num_cols, Mdata, stride, pivot, result);
 }
 
 // 
 inline void clapack_Xgetri2(KaldiBlasInt *num_rows, float *Mdata, KaldiBlasInt *stride,
                            KaldiBlasInt *pivot, float *p_work, 
                            KaldiBlasInt *l_work, KaldiBlasInt *result) {
-  sgetri_(num_rows, Mdata, stride, pivot, p_work, l_work, result);
+  LAPACK_sgetri(num_rows, Mdata, stride, pivot, p_work, l_work, result);
 }
 inline void clapack_Xgetri2(KaldiBlasInt *num_rows, double *Mdata, KaldiBlasInt *stride,
                            KaldiBlasInt *pivot, double *p_work, 
                            KaldiBlasInt *l_work, KaldiBlasInt *result) {
-  dgetri_(num_rows, Mdata, stride, pivot, p_work, l_work, result);
+  LAPACK_dgetri(num_rows, Mdata, stride, pivot, p_work, l_work, result);
 }
 //
 inline void clapack_Xgesvd(char *v, char *u, KaldiBlasInt *num_cols,
@@ -417,7 +419,7 @@ inline void clapack_Xgesvd(char *v, char *u, KaldiBlasInt *num_cols,
                            float *sv, float *Vdata, KaldiBlasInt *vstride,
                            float *Udata, KaldiBlasInt *ustride, float *p_work,
                            KaldiBlasInt *l_work, KaldiBlasInt *result) {
-  sgesvd_(v, u,
+  LAPACK_sgesvd(v, u,
           num_cols, num_rows, Mdata, stride,
           sv, Vdata, vstride, Udata, ustride, 
           p_work, l_work, result); 
@@ -427,7 +429,7 @@ inline void clapack_Xgesvd(char *v, char *u, KaldiBlasInt *num_cols,
                            double *sv, double *Vdata, KaldiBlasInt *vstride,
                            double *Udata, KaldiBlasInt *ustride, double *p_work,
                            KaldiBlasInt *l_work, KaldiBlasInt *result) {
-  dgesvd_(v, u,
+  LAPACK_dgesvd(v, u,
           num_cols, num_rows, Mdata, stride,
           sv, Vdata, vstride, Udata, ustride,
           p_work, l_work, result); 
@@ -435,20 +437,20 @@ inline void clapack_Xgesvd(char *v, char *u, KaldiBlasInt *num_cols,
 //
 void inline clapack_Xsptri(KaldiBlasInt *num_rows, float *Mdata, 
                            KaldiBlasInt *ipiv, float *work, KaldiBlasInt *result) {
-  ssptri_(const_cast<char *>("U"), num_rows, Mdata, ipiv, work, result);
+  LAPACK_ssptri(const_cast<char *>("U"), num_rows, Mdata, ipiv, work, result);
 }
 void inline clapack_Xsptri(KaldiBlasInt *num_rows, double *Mdata, 
                            KaldiBlasInt *ipiv, double *work, KaldiBlasInt *result) {
-  dsptri_(const_cast<char *>("U"), num_rows, Mdata, ipiv, work, result);
+  LAPACK_dsptri(const_cast<char *>("U"), num_rows, Mdata, ipiv, work, result);
 }
 //
 void inline clapack_Xsptrf(KaldiBlasInt *num_rows, float *Mdata,
                            KaldiBlasInt *ipiv, KaldiBlasInt *result) {
-  ssptrf_(const_cast<char *>("U"), num_rows, Mdata, ipiv, result);
+  LAPACK_ssptrf(const_cast<char *>("U"), num_rows, Mdata, ipiv, result);
 }
 void inline clapack_Xsptrf(KaldiBlasInt *num_rows, double *Mdata,
                            KaldiBlasInt *ipiv, KaldiBlasInt *result) {
-  dsptrf_(const_cast<char *>("U"), num_rows, Mdata, ipiv, result);
+  LAPACK_dsptrf(const_cast<char *>("U"), num_rows, Mdata, ipiv, result);
 }
 #else
 inline void clapack_Xgetrf(MatrixIndexT num_rows, MatrixIndexT num_cols,

--- a/src/matrix/cblas-wrappers.h
+++ b/src/matrix/cblas-wrappers.h
@@ -3,6 +3,8 @@
 // Copyright 2012  Johns Hopkins University (author: Daniel Povey);
 //                 Haihua Xu; Wei Shi
 
+// Modified 2022 by Sean Robertson, listed.
+
 // See ../../COPYING for clarification regarding multiple authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,131 +33,138 @@
 // Do not include this file directly.  It is to be included
 // by .cc files in this directory.
 
+#ifdef HAVE_NOBLAS
+  // sdrobert: will throw whenever any of these wrappers are called
+  #define IMP_CHECK(a) throw std::logic_error("not compiled with blas")
+#else
+  #define IMP_CHECK(a) a
+#endif
+
 namespace kaldi {
 
 
 inline void cblas_Xcopy(const int N, const float *X, const int incX, float *Y,
                         const int incY) {
-  cblas_scopy(N, X, incX, Y, incY);
+  IMP_CHECK(cblas_scopy(N, X, incX, Y, incY));
 }
 
 inline void cblas_Xcopy(const int N, const double *X, const int incX, double *Y,
                         const int incY) {
-  cblas_dcopy(N, X, incX, Y, incY);
+  IMP_CHECK(cblas_dcopy(N, X, incX, Y, incY));
 }
 
 
 inline float cblas_Xasum(const int N, const float *X, const int incX) {
-  return cblas_sasum(N, X, incX);
+  IMP_CHECK(return cblas_sasum(N, X, incX));
 }
 
 inline double cblas_Xasum(const int N, const double *X, const int incX) {
-  return cblas_dasum(N, X, incX);
+  IMP_CHECK(return cblas_dasum(N, X, incX));
 }
 
 inline void cblas_Xrot(const int N, float *X, const int incX, float *Y,
                        const int incY, const float c, const float s) {
-  cblas_srot(N, X, incX, Y, incY, c, s);
+  IMP_CHECK(cblas_srot(N, X, incX, Y, incY, c, s));
 }
 inline void cblas_Xrot(const int N, double *X, const int incX, double *Y,
                        const int incY, const double c, const double s) {
-  cblas_drot(N, X, incX, Y, incY, c, s);
+  IMP_CHECK(cblas_drot(N, X, incX, Y, incY, c, s));
 }
 inline float cblas_Xdot(const int N, const float *const X,
                         const int incX, const float *const Y,
                         const int incY) {
-  return cblas_sdot(N, X, incX, Y, incY);
+  IMP_CHECK(return cblas_sdot(N, X, incX, Y, incY));
 }
 inline double cblas_Xdot(const int N, const double *const X,
                         const int incX, const double *const Y,
                         const int incY) {
-  return cblas_ddot(N, X, incX, Y, incY);
+  IMP_CHECK(return cblas_ddot(N, X, incX, Y, incY));
 }
 inline void cblas_Xaxpy(const int N, const float alpha, const float *X,
                         const int incX, float *Y, const int incY) {
-  cblas_saxpy(N, alpha, X, incX, Y, incY);
+  IMP_CHECK(cblas_saxpy(N, alpha, X, incX, Y, incY));
 }
 inline void cblas_Xaxpy(const int N, const double alpha, const double *X,
                         const int incX, double *Y, const int incY) {
-  cblas_daxpy(N, alpha, X, incX, Y, incY);
+  IMP_CHECK(cblas_daxpy(N, alpha, X, incX, Y, incY));
 }
 inline void cblas_Xscal(const int N, const float alpha, float *data,
                         const int inc) {
-  cblas_sscal(N, alpha, data, inc);
+  IMP_CHECK(cblas_sscal(N, alpha, data, inc));
 }
 inline void cblas_Xscal(const int N, const double alpha, double *data, 
                         const int inc) {
-  cblas_dscal(N, alpha, data, inc);
+  IMP_CHECK(cblas_dscal(N, alpha, data, inc));
 }
 inline void cblas_Xspmv(const float alpha, const int num_rows, const float *Mdata,
                         const float *v, const int v_inc,
                         const float beta, float *y, const int y_inc) {
-  cblas_sspmv(CblasRowMajor, CblasLower, num_rows, alpha, Mdata, v, v_inc, beta, y, y_inc);
+  IMP_CHECK(cblas_sspmv(CblasRowMajor, CblasLower, num_rows, alpha, Mdata, v, v_inc, beta, y, y_inc));
 }
 inline void cblas_Xspmv(const double alpha, const int num_rows, const double *Mdata,
                         const double *v, const int v_inc,
                         const double beta, double *y, const int y_inc) {
-  cblas_dspmv(CblasRowMajor, CblasLower, num_rows, alpha, Mdata, v, v_inc, beta, y, y_inc);
+  IMP_CHECK(cblas_dspmv(CblasRowMajor, CblasLower, num_rows, alpha, Mdata, v, v_inc, beta, y, y_inc));
 }
 inline void cblas_Xtpmv(MatrixTransposeType trans, const float *Mdata,
                         const int num_rows, float *y, const int y_inc) {
-  cblas_stpmv(CblasRowMajor, CblasLower, static_cast<CBLAS_TRANSPOSE>(trans),
-              CblasNonUnit, num_rows, Mdata, y, y_inc);
+  IMP_CHECK(cblas_stpmv(CblasRowMajor, CblasLower, static_cast<CBLAS_TRANSPOSE>(trans),
+              CblasNonUnit, num_rows, Mdata, y, y_inc));
 }
 inline void cblas_Xtpmv(MatrixTransposeType trans, const double *Mdata,
                         const int num_rows, double *y, const int y_inc) {
-  cblas_dtpmv(CblasRowMajor, CblasLower, static_cast<CBLAS_TRANSPOSE>(trans),
-              CblasNonUnit, num_rows, Mdata, y, y_inc);
+  IMP_CHECK(cblas_dtpmv(CblasRowMajor, CblasLower, static_cast<CBLAS_TRANSPOSE>(trans),
+              CblasNonUnit, num_rows, Mdata, y, y_inc));
 }
 
 
 inline void cblas_Xtpsv(MatrixTransposeType trans, const float *Mdata,
                         const int num_rows, float *y, const int y_inc) {
-  cblas_stpsv(CblasRowMajor, CblasLower, static_cast<CBLAS_TRANSPOSE>(trans),
-              CblasNonUnit, num_rows, Mdata, y, y_inc);
+  IMP_CHECK(cblas_stpsv(CblasRowMajor, CblasLower, static_cast<CBLAS_TRANSPOSE>(trans),
+              CblasNonUnit, num_rows, Mdata, y, y_inc));
 }
 inline void cblas_Xtpsv(MatrixTransposeType trans, const double *Mdata,
                         const int num_rows, double *y, const int y_inc) {
-  cblas_dtpsv(CblasRowMajor, CblasLower, static_cast<CBLAS_TRANSPOSE>(trans),
-              CblasNonUnit, num_rows, Mdata, y, y_inc);
+  IMP_CHECK(cblas_dtpsv(CblasRowMajor, CblasLower, static_cast<CBLAS_TRANSPOSE>(trans),
+              CblasNonUnit, num_rows, Mdata, y, y_inc));
 }
 
 // x = alpha * M * y + beta * x
 inline void cblas_Xspmv(MatrixIndexT dim, float alpha, const float *Mdata,
                         const float *ydata, MatrixIndexT ystride,
                         float beta, float *xdata, MatrixIndexT xstride) {
-  cblas_sspmv(CblasRowMajor, CblasLower, dim, alpha, Mdata,
-              ydata, ystride, beta, xdata, xstride);
+  IMP_CHECK(cblas_sspmv(CblasRowMajor, CblasLower, dim, alpha, Mdata,
+              ydata, ystride, beta, xdata, xstride));
 }
 inline void cblas_Xspmv(MatrixIndexT dim, double alpha, const double *Mdata,
                         const double *ydata, MatrixIndexT ystride,
                         double beta, double *xdata, MatrixIndexT xstride) {
-  cblas_dspmv(CblasRowMajor, CblasLower, dim, alpha, Mdata,
-              ydata, ystride, beta, xdata, xstride);
+  IMP_CHECK(cblas_dspmv(CblasRowMajor, CblasLower, dim, alpha, Mdata,
+              ydata, ystride, beta, xdata, xstride));
 }
 
 // Implements  A += alpha * (x y'  + y x'); A is symmetric matrix.
 inline void cblas_Xspr2(MatrixIndexT dim, float alpha, const float *Xdata,
                         MatrixIndexT incX, const float *Ydata, MatrixIndexT incY,
                           float *Adata) {
-  cblas_sspr2(CblasRowMajor, CblasLower, dim, alpha, Xdata,
-              incX, Ydata, incY, Adata);
+  IMP_CHECK(cblas_sspr2(CblasRowMajor, CblasLower, dim, alpha, Xdata,
+              incX, Ydata, incY, Adata));
 }
 inline void cblas_Xspr2(MatrixIndexT dim, double alpha, const double *Xdata,
                         MatrixIndexT incX, const double *Ydata, MatrixIndexT incY,
                         double *Adata) {
-  cblas_dspr2(CblasRowMajor, CblasLower, dim, alpha, Xdata,
-              incX, Ydata, incY, Adata);
+  IMP_CHECK(cblas_dspr2(CblasRowMajor, CblasLower, dim, alpha, Xdata,
+              incX, Ydata, incY, Adata));
 }
 
 // Implements  A += alpha * (x x'); A is symmetric matrix.
 inline void cblas_Xspr(MatrixIndexT dim, float alpha, const float *Xdata,
                        MatrixIndexT incX, float *Adata) {
-  cblas_sspr(CblasRowMajor, CblasLower, dim, alpha, Xdata, incX, Adata);
+  IMP_CHECK(cblas_sspr(CblasRowMajor, CblasLower, dim, alpha, Xdata, incX, Adata));
 }
 inline void cblas_Xspr(MatrixIndexT dim, double alpha, const double *Xdata,
                        MatrixIndexT incX, double *Adata) {
-  cblas_dspr(CblasRowMajor, CblasLower, dim, alpha, Xdata, incX, Adata);
+  IMP_CHECK(cblas_dspr(CblasRowMajor, CblasLower, dim, alpha, Xdata, incX, Adata));
 }
 
 // sgemv,dgemv: y = alpha M x + beta y.
@@ -163,15 +172,15 @@ inline void cblas_Xgemv(MatrixTransposeType trans, MatrixIndexT num_rows,
                         MatrixIndexT num_cols, float alpha, const float *Mdata,
                         MatrixIndexT stride, const float *xdata,
                         MatrixIndexT incX, float beta, float *ydata, MatrixIndexT incY) {
-  cblas_sgemv(CblasRowMajor, static_cast<CBLAS_TRANSPOSE>(trans), num_rows,
-              num_cols, alpha, Mdata, stride, xdata, incX, beta, ydata, incY);
+  IMP_CHECK(cblas_sgemv(CblasRowMajor, static_cast<CBLAS_TRANSPOSE>(trans), num_rows,
+              num_cols, alpha, Mdata, stride, xdata, incX, beta, ydata, incY));
 }
 inline void cblas_Xgemv(MatrixTransposeType trans, MatrixIndexT num_rows,
                         MatrixIndexT num_cols, double alpha, const double *Mdata,
                         MatrixIndexT stride, const double *xdata,
                         MatrixIndexT incX, double beta, double *ydata, MatrixIndexT incY) {
-  cblas_dgemv(CblasRowMajor, static_cast<CBLAS_TRANSPOSE>(trans), num_rows,
-              num_cols, alpha, Mdata, stride, xdata, incX, beta, ydata, incY);
+  IMP_CHECK(cblas_dgemv(CblasRowMajor, static_cast<CBLAS_TRANSPOSE>(trans), num_rows,
+              num_cols, alpha, Mdata, stride, xdata, incX, beta, ydata, incY));
 }
 
 // sgbmv, dgmmv: y = alpha M x +  + beta * y.
@@ -180,18 +189,18 @@ inline void cblas_Xgbmv(MatrixTransposeType trans, MatrixIndexT num_rows,
                         MatrixIndexT num_above, float alpha, const float *Mdata,
                         MatrixIndexT stride, const float *xdata,
                         MatrixIndexT incX, float beta, float *ydata, MatrixIndexT incY) {
-  cblas_sgbmv(CblasRowMajor, static_cast<CBLAS_TRANSPOSE>(trans), num_rows,
+  IMP_CHECK(cblas_sgbmv(CblasRowMajor, static_cast<CBLAS_TRANSPOSE>(trans), num_rows,
               num_cols, num_below, num_above, alpha, Mdata, stride, xdata,
-              incX, beta, ydata, incY);
+              incX, beta, ydata, incY));
 }
 inline void cblas_Xgbmv(MatrixTransposeType trans, MatrixIndexT num_rows,
                         MatrixIndexT num_cols, MatrixIndexT num_below,
                         MatrixIndexT num_above, double alpha, const double *Mdata,
                         MatrixIndexT stride, const double *xdata,
                         MatrixIndexT incX, double beta, double *ydata, MatrixIndexT incY) {
-  cblas_dgbmv(CblasRowMajor, static_cast<CBLAS_TRANSPOSE>(trans), num_rows,
+  IMP_CHECK(cblas_dgbmv(CblasRowMajor, static_cast<CBLAS_TRANSPOSE>(trans), num_rows,
               num_cols, num_below, num_above, alpha, Mdata, stride, xdata,
-              incX, beta, ydata, incY);
+              incX, beta, ydata, incY));
 }
 
 
@@ -230,11 +239,11 @@ inline void cblas_Xgemm(const float alpha,
                         const float beta,
                         float *Mdata, 
                         MatrixIndexT num_rows, MatrixIndexT num_cols,MatrixIndexT stride) {
-  cblas_sgemm(CblasRowMajor, static_cast<CBLAS_TRANSPOSE>(transA), 
+  IMP_CHECK(cblas_sgemm(CblasRowMajor, static_cast<CBLAS_TRANSPOSE>(transA), 
               static_cast<CBLAS_TRANSPOSE>(transB),
               num_rows, num_cols, transA == kNoTrans ? a_num_cols : a_num_rows,
               alpha, Adata, a_stride, Bdata, b_stride,
-              beta, Mdata, stride); 
+              beta, Mdata, stride)); 
 }
 inline void cblas_Xgemm(const double alpha,
                         MatrixTransposeType transA,
@@ -245,11 +254,11 @@ inline void cblas_Xgemm(const double alpha,
                         const double beta,
                         double *Mdata, 
                         MatrixIndexT num_rows, MatrixIndexT num_cols,MatrixIndexT stride) {
-  cblas_dgemm(CblasRowMajor, static_cast<CBLAS_TRANSPOSE>(transA), 
+  IMP_CHECK(cblas_dgemm(CblasRowMajor, static_cast<CBLAS_TRANSPOSE>(transA), 
               static_cast<CBLAS_TRANSPOSE>(transB),
               num_rows, num_cols, transA == kNoTrans ? a_num_cols : a_num_rows,
               alpha, Adata, a_stride, Bdata, b_stride,
-              beta, Mdata, stride); 
+              beta, Mdata, stride)); 
 }
 
 
@@ -259,8 +268,8 @@ inline void cblas_Xsymm(const float alpha,
                         const float *Bdata,MatrixIndexT b_stride,
                         const float beta,
                         float *Mdata, MatrixIndexT stride) {
-  cblas_ssymm(CblasRowMajor, CblasLeft, CblasLower, sz, sz, alpha, Adata,
-              a_stride, Bdata, b_stride, beta, Mdata, stride);
+  IMP_CHECK(cblas_ssymm(CblasRowMajor, CblasLeft, CblasLower, sz, sz, alpha, Adata,
+              a_stride, Bdata, b_stride, beta, Mdata, stride));
 }
 inline void cblas_Xsymm(const double alpha,
                         MatrixIndexT sz,
@@ -268,21 +277,21 @@ inline void cblas_Xsymm(const double alpha,
                         const double *Bdata,MatrixIndexT b_stride,
                         const double beta,
                         double *Mdata, MatrixIndexT stride) {
-  cblas_dsymm(CblasRowMajor, CblasLeft, CblasLower, sz, sz, alpha, Adata,
-              a_stride, Bdata, b_stride, beta, Mdata, stride);
+  IMP_CHECK(cblas_dsymm(CblasRowMajor, CblasLeft, CblasLower, sz, sz, alpha, Adata,
+              a_stride, Bdata, b_stride, beta, Mdata, stride));
 }
 // ger: M += alpha x y^T.
 inline void cblas_Xger(MatrixIndexT num_rows, MatrixIndexT num_cols, float alpha,
                        const float *xdata, MatrixIndexT incX, const float *ydata,
                        MatrixIndexT incY, float *Mdata, MatrixIndexT stride) {
-  cblas_sger(CblasRowMajor, num_rows, num_cols, alpha, xdata, 1, ydata, 1,
-             Mdata, stride);
+  IMP_CHECK(cblas_sger(CblasRowMajor, num_rows, num_cols, alpha, xdata, 1, ydata, 1,
+             Mdata, stride));
 }
 inline void cblas_Xger(MatrixIndexT num_rows, MatrixIndexT num_cols, double alpha,
                        const double *xdata, MatrixIndexT incX, const double *ydata,
                        MatrixIndexT incY, double *Mdata, MatrixIndexT stride) {
-  cblas_dger(CblasRowMajor, num_rows, num_cols, alpha, xdata, 1, ydata, 1,
-             Mdata, stride);
+  IMP_CHECK(cblas_dger(CblasRowMajor, num_rows, num_cols, alpha, xdata, 1, ydata, 1,
+             Mdata, stride));
 }
 
 // syrk: symmetric rank-k update.
@@ -297,8 +306,8 @@ inline void cblas_Xsyrk (
     const MatrixIndexT other_dim_a, const float alpha, const float *A,
     const MatrixIndexT a_stride, const float beta, float *C,
     const MatrixIndexT c_stride) {
-  cblas_ssyrk(CblasRowMajor, CblasLower, static_cast<CBLAS_TRANSPOSE>(trans),
-              dim_c, other_dim_a, alpha, A, a_stride, beta, C, c_stride);
+  IMP_CHECK(cblas_ssyrk(CblasRowMajor, CblasLower, static_cast<CBLAS_TRANSPOSE>(trans),
+              dim_c, other_dim_a, alpha, A, a_stride, beta, C, c_stride));
 }
 
 inline void cblas_Xsyrk(
@@ -306,8 +315,8 @@ inline void cblas_Xsyrk(
     const MatrixIndexT other_dim_a, const double alpha, const double *A,
     const MatrixIndexT a_stride, const double beta, double *C,
     const MatrixIndexT c_stride) {
-  cblas_dsyrk(CblasRowMajor, CblasLower, static_cast<CBLAS_TRANSPOSE>(trans),
-              dim_c, other_dim_a, alpha, A, a_stride, beta, C, c_stride);
+  IMP_CHECK(cblas_dsyrk(CblasRowMajor, CblasLower, static_cast<CBLAS_TRANSPOSE>(trans),
+              dim_c, other_dim_a, alpha, A, a_stride, beta, C, c_stride));
 }
 
 /// matrix-vector multiply using a banded matrix; we always call this
@@ -321,8 +330,8 @@ inline void cblas_Xsbmv1(
     const double *x,
     const double beta,
     double *y) {
-  cblas_dsbmv(CblasRowMajor, CblasLower, dim, 0, alpha, A,
-              1, x, 1, beta, y, 1);
+  IMP_CHECK(cblas_dsbmv(CblasRowMajor, CblasLower, dim, 0, alpha, A,
+              1, x, 1, beta, y, 1));
 }
 
 inline void cblas_Xsbmv1(
@@ -332,8 +341,8 @@ inline void cblas_Xsbmv1(
     const float *x,
     const float beta,
     float *y) {
-  cblas_ssbmv(CblasRowMajor, CblasLower, dim, 0, alpha, A,
-              1, x, 1, beta, y, 1);
+  IMP_CHECK(cblas_ssbmv(CblasRowMajor, CblasLower, dim, 0, alpha, A,
+              1, x, 1, beta, y, 1));
 }
 
 /// This is not really a wrapper for CBLAS as CBLAS does not have this; in future we could
@@ -383,33 +392,33 @@ inline void mul_elements(
 // add clapack here
 #if !defined(HAVE_ATLAS)
 inline void clapack_Xtptri(KaldiBlasInt *num_rows, float *Mdata, KaldiBlasInt *result) {
-  stptri_(const_cast<char *>("U"), const_cast<char *>("N"), num_rows, Mdata, result);
+  IMP_CHECK(stptri_(const_cast<char *>("U"), const_cast<char *>("N"), num_rows, Mdata, result));
 }
 inline void clapack_Xtptri(KaldiBlasInt *num_rows, double *Mdata, KaldiBlasInt *result) {
-  dtptri_(const_cast<char *>("U"), const_cast<char *>("N"), num_rows, Mdata, result);
+  IMP_CHECK(dtptri_(const_cast<char *>("U"), const_cast<char *>("N"), num_rows, Mdata, result));
 }
 // 
 inline void clapack_Xgetrf2(KaldiBlasInt *num_rows, KaldiBlasInt *num_cols, 
                             float *Mdata, KaldiBlasInt *stride, KaldiBlasInt *pivot, 
                             KaldiBlasInt *result) {
-  sgetrf_(num_rows, num_cols, Mdata, stride, pivot, result);
+  IMP_CHECK(sgetrf_(num_rows, num_cols, Mdata, stride, pivot, result));
 }
 inline void clapack_Xgetrf2(KaldiBlasInt *num_rows, KaldiBlasInt *num_cols, 
                             double *Mdata, KaldiBlasInt *stride, KaldiBlasInt *pivot, 
                             KaldiBlasInt *result) {
-  dgetrf_(num_rows, num_cols, Mdata, stride, pivot, result);
+  IMP_CHECK(dgetrf_(num_rows, num_cols, Mdata, stride, pivot, result));
 }
 
 // 
 inline void clapack_Xgetri2(KaldiBlasInt *num_rows, float *Mdata, KaldiBlasInt *stride,
                            KaldiBlasInt *pivot, float *p_work, 
                            KaldiBlasInt *l_work, KaldiBlasInt *result) {
-  sgetri_(num_rows, Mdata, stride, pivot, p_work, l_work, result);
+  IMP_CHECK(sgetri_(num_rows, Mdata, stride, pivot, p_work, l_work, result));
 }
 inline void clapack_Xgetri2(KaldiBlasInt *num_rows, double *Mdata, KaldiBlasInt *stride,
                            KaldiBlasInt *pivot, double *p_work, 
                            KaldiBlasInt *l_work, KaldiBlasInt *result) {
-  dgetri_(num_rows, Mdata, stride, pivot, p_work, l_work, result);
+  IMP_CHECK(dgetri_(num_rows, Mdata, stride, pivot, p_work, l_work, result));
 }
 //
 inline void clapack_Xgesvd(char *v, char *u, KaldiBlasInt *num_cols,
@@ -417,40 +426,41 @@ inline void clapack_Xgesvd(char *v, char *u, KaldiBlasInt *num_cols,
                            float *sv, float *Vdata, KaldiBlasInt *vstride,
                            float *Udata, KaldiBlasInt *ustride, float *p_work,
                            KaldiBlasInt *l_work, KaldiBlasInt *result) {
-  sgesvd_(v, u,
+  IMP_CHECK(sgesvd_(v, u,
           num_cols, num_rows, Mdata, stride,
           sv, Vdata, vstride, Udata, ustride, 
-          p_work, l_work, result); 
+          p_work, l_work, result)); 
 }
 inline void clapack_Xgesvd(char *v, char *u, KaldiBlasInt *num_cols,
                            KaldiBlasInt *num_rows, double *Mdata, KaldiBlasInt *stride,
                            double *sv, double *Vdata, KaldiBlasInt *vstride,
                            double *Udata, KaldiBlasInt *ustride, double *p_work,
                            KaldiBlasInt *l_work, KaldiBlasInt *result) {
-  dgesvd_(v, u,
+  IMP_CHECK(dgesvd_(v, u,
           num_cols, num_rows, Mdata, stride,
           sv, Vdata, vstride, Udata, ustride,
-          p_work, l_work, result); 
+          p_work, l_work, result)); 
 }
 //
 void inline clapack_Xsptri(KaldiBlasInt *num_rows, float *Mdata, 
                            KaldiBlasInt *ipiv, float *work, KaldiBlasInt *result) {
-  ssptri_(const_cast<char *>("U"), num_rows, Mdata, ipiv, work, result);
+  IMP_CHECK(ssptri_(const_cast<char *>("U"), num_rows, Mdata, ipiv, work, result));
 }
 void inline clapack_Xsptri(KaldiBlasInt *num_rows, double *Mdata, 
                            KaldiBlasInt *ipiv, double *work, KaldiBlasInt *result) {
-  dsptri_(const_cast<char *>("U"), num_rows, Mdata, ipiv, work, result);
+  IMP_CHECK(dsptri_(const_cast<char *>("U"), num_rows, Mdata, ipiv, work, result));
 }
 //
 void inline clapack_Xsptrf(KaldiBlasInt *num_rows, float *Mdata,
                            KaldiBlasInt *ipiv, KaldiBlasInt *result) {
-  ssptrf_(const_cast<char *>("U"), num_rows, Mdata, ipiv, result);
+  IMP_CHECK(ssptrf_(const_cast<char *>("U"), num_rows, Mdata, ipiv, result));
 }
 void inline clapack_Xsptrf(KaldiBlasInt *num_rows, double *Mdata,
                            KaldiBlasInt *ipiv, KaldiBlasInt *result) {
-  dsptrf_(const_cast<char *>("U"), num_rows, Mdata, ipiv, result);
+  IMP_CHECK(dsptrf_(const_cast<char *>("U"), num_rows, Mdata, ipiv, result));
 }
 #else
+// sdrobert: no need for IMP_CHECK - HAVE_ATLAS is true
 inline void clapack_Xgetrf(MatrixIndexT num_rows, MatrixIndexT num_cols,
                            float *Mdata, MatrixIndexT stride, 
                            int *pivot, int *result) {

--- a/src/matrix/cblas-wrappers.h
+++ b/src/matrix/cblas-wrappers.h
@@ -3,8 +3,6 @@
 // Copyright 2012  Johns Hopkins University (author: Daniel Povey);
 //                 Haihua Xu; Wei Shi
 
-// Modified 2022 by Sean Robertson, listed.
-
 // See ../../COPYING for clarification regarding multiple authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -381,37 +379,37 @@ inline void mul_elements(
 }
 
 
+
+// add clapack here
 #if !defined(HAVE_ATLAS)
-// sdrobert: updated to include the LAPACK_ prefix, which is what is exposed
-// in lapack.h
 inline void clapack_Xtptri(KaldiBlasInt *num_rows, float *Mdata, KaldiBlasInt *result) {
-  LAPACK_stptri(const_cast<char *>("U"), const_cast<char *>("N"), num_rows, Mdata, result);
+  stptri_(const_cast<char *>("U"), const_cast<char *>("N"), num_rows, Mdata, result);
 }
 inline void clapack_Xtptri(KaldiBlasInt *num_rows, double *Mdata, KaldiBlasInt *result) {
-  LAPACK_dtptri(const_cast<char *>("U"), const_cast<char *>("N"), num_rows, Mdata, result);
+  dtptri_(const_cast<char *>("U"), const_cast<char *>("N"), num_rows, Mdata, result);
 }
 // 
 inline void clapack_Xgetrf2(KaldiBlasInt *num_rows, KaldiBlasInt *num_cols, 
                             float *Mdata, KaldiBlasInt *stride, KaldiBlasInt *pivot, 
                             KaldiBlasInt *result) {
-  LAPACK_sgetrf(num_rows, num_cols, Mdata, stride, pivot, result);
+  sgetrf_(num_rows, num_cols, Mdata, stride, pivot, result);
 }
 inline void clapack_Xgetrf2(KaldiBlasInt *num_rows, KaldiBlasInt *num_cols, 
                             double *Mdata, KaldiBlasInt *stride, KaldiBlasInt *pivot, 
                             KaldiBlasInt *result) {
-  LAPACK_dgetrf(num_rows, num_cols, Mdata, stride, pivot, result);
+  dgetrf_(num_rows, num_cols, Mdata, stride, pivot, result);
 }
 
 // 
 inline void clapack_Xgetri2(KaldiBlasInt *num_rows, float *Mdata, KaldiBlasInt *stride,
                            KaldiBlasInt *pivot, float *p_work, 
                            KaldiBlasInt *l_work, KaldiBlasInt *result) {
-  LAPACK_sgetri(num_rows, Mdata, stride, pivot, p_work, l_work, result);
+  sgetri_(num_rows, Mdata, stride, pivot, p_work, l_work, result);
 }
 inline void clapack_Xgetri2(KaldiBlasInt *num_rows, double *Mdata, KaldiBlasInt *stride,
                            KaldiBlasInt *pivot, double *p_work, 
                            KaldiBlasInt *l_work, KaldiBlasInt *result) {
-  LAPACK_dgetri(num_rows, Mdata, stride, pivot, p_work, l_work, result);
+  dgetri_(num_rows, Mdata, stride, pivot, p_work, l_work, result);
 }
 //
 inline void clapack_Xgesvd(char *v, char *u, KaldiBlasInt *num_cols,
@@ -419,7 +417,7 @@ inline void clapack_Xgesvd(char *v, char *u, KaldiBlasInt *num_cols,
                            float *sv, float *Vdata, KaldiBlasInt *vstride,
                            float *Udata, KaldiBlasInt *ustride, float *p_work,
                            KaldiBlasInt *l_work, KaldiBlasInt *result) {
-  LAPACK_sgesvd(v, u,
+  sgesvd_(v, u,
           num_cols, num_rows, Mdata, stride,
           sv, Vdata, vstride, Udata, ustride, 
           p_work, l_work, result); 
@@ -429,7 +427,7 @@ inline void clapack_Xgesvd(char *v, char *u, KaldiBlasInt *num_cols,
                            double *sv, double *Vdata, KaldiBlasInt *vstride,
                            double *Udata, KaldiBlasInt *ustride, double *p_work,
                            KaldiBlasInt *l_work, KaldiBlasInt *result) {
-  LAPACK_dgesvd(v, u,
+  dgesvd_(v, u,
           num_cols, num_rows, Mdata, stride,
           sv, Vdata, vstride, Udata, ustride,
           p_work, l_work, result); 
@@ -437,20 +435,20 @@ inline void clapack_Xgesvd(char *v, char *u, KaldiBlasInt *num_cols,
 //
 void inline clapack_Xsptri(KaldiBlasInt *num_rows, float *Mdata, 
                            KaldiBlasInt *ipiv, float *work, KaldiBlasInt *result) {
-  LAPACK_ssptri(const_cast<char *>("U"), num_rows, Mdata, ipiv, work, result);
+  ssptri_(const_cast<char *>("U"), num_rows, Mdata, ipiv, work, result);
 }
 void inline clapack_Xsptri(KaldiBlasInt *num_rows, double *Mdata, 
                            KaldiBlasInt *ipiv, double *work, KaldiBlasInt *result) {
-  LAPACK_dsptri(const_cast<char *>("U"), num_rows, Mdata, ipiv, work, result);
+  dsptri_(const_cast<char *>("U"), num_rows, Mdata, ipiv, work, result);
 }
 //
 void inline clapack_Xsptrf(KaldiBlasInt *num_rows, float *Mdata,
                            KaldiBlasInt *ipiv, KaldiBlasInt *result) {
-  LAPACK_ssptrf(const_cast<char *>("U"), num_rows, Mdata, ipiv, result);
+  ssptrf_(const_cast<char *>("U"), num_rows, Mdata, ipiv, result);
 }
 void inline clapack_Xsptrf(KaldiBlasInt *num_rows, double *Mdata,
                            KaldiBlasInt *ipiv, KaldiBlasInt *result) {
-  LAPACK_dsptrf(const_cast<char *>("U"), num_rows, Mdata, ipiv, result);
+  dsptrf_(const_cast<char *>("U"), num_rows, Mdata, ipiv, result);
 }
 #else
 inline void clapack_Xgetrf(MatrixIndexT num_rows, MatrixIndexT num_cols,

--- a/src/matrix/kaldi-blas.h
+++ b/src/matrix/kaldi-blas.h
@@ -2,7 +2,7 @@
 
 // Copyright 2009-2011  Ondrej Glembek;  Microsoft Corporation
 
-// Modified 2022 by Sean Robertson, listed.
+// Modified 2021 by Sean Robertson, listed.
 
 // See ../../COPYING for clarification regarding multiple authors
 //
@@ -109,8 +109,7 @@
 #endif
 
   #include "cblas.h"
-  // sdrobert: don't need the high-level lapacke routines, just lapack
-  #include "lapack.h"
+  #include "lapacke.h"
   #undef I
   #undef complex
   // get rid of macros from f2c.h -- these are dangerous.

--- a/src/matrix/kaldi-blas.h
+++ b/src/matrix/kaldi-blas.h
@@ -2,7 +2,7 @@
 
 // Copyright 2009-2011  Ondrej Glembek;  Microsoft Corporation
 
-// Modified 2021 by Sean Robertson, listed.
+// Modified 2022 by Sean Robertson, listed.
 
 // See ../../COPYING for clarification regarding multiple authors
 //
@@ -109,7 +109,8 @@
 #endif
 
   #include "cblas.h"
-  #include "lapacke.h"
+  // sdrobert: don't need the high-level lapacke routines, just lapack
+  #include "lapack.h"
   #undef I
   #undef complex
   // get rid of macros from f2c.h -- these are dangerous.

--- a/src/matrix/kaldi-blas.h
+++ b/src/matrix/kaldi-blas.h
@@ -2,7 +2,7 @@
 
 // Copyright 2009-2011  Ondrej Glembek;  Microsoft Corporation
 
-// Modified 2021 by Sean Robertson, listed.
+// Modified 2022 by Sean Robertson, listed.
 
 // See ../../COPYING for clarification regarding multiple authors
 //
@@ -44,11 +44,12 @@
 // supply its own "by hand" implementation which is based on TNT code.
 
 
-
-
-#if (defined(HAVE_CLAPACK) && (defined(HAVE_ATLAS) || defined(HAVE_MKL))) \
-    || (defined(HAVE_ATLAS) && defined(HAVE_MKL))
-#error "Do not define more than one of HAVE_CLAPACK, HAVE_ATLAS and HAVE_MKL"
+// sdrobert: updated
+#if (defined(HAVE_CLAPACK) && (defined(HAVE_ATLAS) || defined(HAVE_MKL) || defined(HAVE_OPENBLAS) || defined(HAVE_NOBLAS))) \
+    || (defined(HAVE_ATLAS) && (defined(HAVE_MKL) || defined(HAVE_OPENBLAS) || defined(HAVE_NOBLAS))) \
+    || (defined(HAVE_MKL) && (defined(HAVE_OPENBLAS) || defined(HAVE_NOBLAS))) \
+    || (defined(HAVE_OPENBLAS) && defined(HAVE_NOBLAS))
+#error "Do not define more than one of HAVE_CLAPACK, HAVE_ATLAS, HAVE_MKL, HAVE_OPENBLAS, and HAVE_NOBLAS"
 #endif
 
 #ifdef HAVE_ATLAS
@@ -122,8 +123,12 @@
   #undef bit_test
   #undef bit_clear
   #undef bit_set
+// sdrobert
+#elif defined(HAVE_NOBLAS)
+  #warning "Compiling without BLAS! Will throw if you try to use it"
 #else
-  #error "You need to define (using the preprocessor) either HAVE_CLAPACK or HAVE_ATLAS or HAVE_MKL (but not more than one)"
+  // sdrobert: updated text
+  #error "You need to define (using the preprocessor) either HAVE_CLAPACK, HAVE_ATLAS, HAVE_MKL, HAVE_OPENBLAS, or HAVE_NOBLAS (but not more than one)"
 #endif
 
 #ifdef HAVE_OPENBLAS
@@ -135,7 +140,17 @@ typedef integer KaldiBlasInt;
 #ifdef HAVE_MKL
 typedef MKL_INT KaldiBlasInt;
 #endif
+// sdrobert
+#ifdef HAVE_NOBLAS
+typedef int KaldiBlasInt;
 
+// from netlib reference cblas.h https://netlib.org/blas/cblas.h
+enum CBLAS_ORDER {CblasRowMajor=101, CblasColMajor=102};
+enum CBLAS_TRANSPOSE {CblasNoTrans=111, CblasTrans=112, CblasConjTrans=113};
+enum CBLAS_UPLO {CblasUpper=121, CblasLower=122};
+enum CBLAS_DIAG {CblasNonUnit=131, CblasUnit=132};
+enum CBLAS_SIDE {CblasLeft=141, CblasRight=142};
+#endif
 #ifdef HAVE_ATLAS
 // in this case there is no need for KaldiBlasInt-- this typedef is only needed
 // for Svd code which is not included in ATLAS (we re-implement it).

--- a/src/matrix/kaldi-blas.h
+++ b/src/matrix/kaldi-blas.h
@@ -125,7 +125,14 @@
   #undef bit_set
 // sdrobert
 #elif defined(HAVE_NOBLAS)
-  #warning "Compiling without BLAS! Will throw if you try to use it"
+  #pragma message "Compiling without BLAS! Will throw if you try to use it"
+
+  // from netlib reference cblas.h https://netlib.org/blas/cblas.h
+  enum CBLAS_ORDER {CblasRowMajor=101, CblasColMajor=102};
+  enum CBLAS_TRANSPOSE {CblasNoTrans=111, CblasTrans=112, CblasConjTrans=113};
+  enum CBLAS_UPLO {CblasUpper=121, CblasLower=122};
+  enum CBLAS_DIAG {CblasNonUnit=131, CblasUnit=132};
+  enum CBLAS_SIDE {CblasLeft=141, CblasRight=142};
 #else
   // sdrobert: updated text
   #error "You need to define (using the preprocessor) either HAVE_CLAPACK, HAVE_ATLAS, HAVE_MKL, HAVE_OPENBLAS, or HAVE_NOBLAS (but not more than one)"
@@ -143,13 +150,6 @@ typedef MKL_INT KaldiBlasInt;
 // sdrobert
 #ifdef HAVE_NOBLAS
 typedef int KaldiBlasInt;
-
-// from netlib reference cblas.h https://netlib.org/blas/cblas.h
-enum CBLAS_ORDER {CblasRowMajor=101, CblasColMajor=102};
-enum CBLAS_TRANSPOSE {CblasNoTrans=111, CblasTrans=112, CblasConjTrans=113};
-enum CBLAS_UPLO {CblasUpper=121, CblasLower=122};
-enum CBLAS_DIAG {CblasNonUnit=131, CblasUnit=132};
-enum CBLAS_SIDE {CblasLeft=141, CblasRight=142};
 #endif
 #ifdef HAVE_ATLAS
 // in this case there is no need for KaldiBlasInt-- this typedef is only needed

--- a/src/pydrobert/kaldi/__init__.py
+++ b/src/pydrobert/kaldi/__init__.py
@@ -27,6 +27,6 @@ __all__ = [
 ]
 
 try:
-    from .version import version as __version__  # type: ignore
+    from ._version import version as __version__  # type: ignore
 except ImportError:
     __version__ = "inplace"

--- a/swig/pydrobert/kaldi.i
+++ b/swig/pydrobert/kaldi.i
@@ -19,7 +19,6 @@
 
 %{
   #define SWIG_FILE_WITH_INIT
-  #define SWIG_PYTHON_2_UNICODE
 %}
 
 #include "base/version.h"


### PR DESCRIPTION
In working on the conda recipe, I found out that

1. The Lapacke BLAS build doesn't actually use lapacke - only lapack.
2. None of the wrapped functionality so far actually uses BLAS.

Linkage was updated in setup.py for 1. For 2, the a "no BLAS" build was hacked together to throw a C++ exception if BLAS is ever tried. This is now the default build for CI.

In addition, I updated `setup.cfg` and added `pyproject.toml` to clean up a bit.