### PR TITLE
Remove py3.11 from CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,22 +10,24 @@ environment:
   CIBW_BEFORE_ALL_WINDOWS: powershell.exe {project}/recipe/cibw_before_all_win.ps1
   CIBW_BEFORE_BUILD: python -m pip install -r {project}/recipe/cibw_before_requirements.txt
   CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: delvewheel repair -w {dest_dir} {wheel} --add-path "C:\Libraries\openblas\bin"
-  CIBW_SKIP: pp* *-win32 *-manylinux*
+  CIBW_SKIP: pp* *-win32 *-manylinux* cp311*
+  # FIXME(sdrobert): include python 3.11 when Numpy has a wheel for it
+  # https://github.com/numpy/numpy/issues/21970
   matrix:
     - job_name: win64
-      CIBW_SKIP: pp* *-win32
+      CIBW_SKIP: pp* *-win32 cp311*
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     - job_name: osx
-      CIBW_SKIP: pp*
+      CIBW_SKIP: pp* cp311*
       APPVEYOR_BUILD_WORKER_IMAGE: macos-mojave
     - job_name: manylinux-x86_64
       CIBW_ARCHS_LINUX: x86_64
-      CIBW_SKIP: pp* *-musllinux*
+      CIBW_SKIP: pp* *-musllinux* cp311*
       # CIBW_ENVIRONMENT_LINUX: OPENBLASROOT=/usr
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
     - job_name: manylinux-i686
       CIBW_ARCHS_LINUX: i686
-      CIBW_SKIP: pp* *-musllinux*
+      CIBW_SKIP: pp* *-musllinux* cp311*
       # CIBW_ENVIRONMENT_LINUX: ATLASROOT=/usr
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
     # FIXME(sdrobert): These work last I checked, but time out. Numpy currently


### PR DESCRIPTION
cibuildwheel was updated to include python 3.11, but [Numpy doesn't fully support it yet](https://github.com/numpy/numpy/issues/21970). Skip 3.11 for the time being.