### PR TITLE
Bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v0.6.3
+------
+- Fixed an annoying bug causing memory bloat.
+
 v0.6.2
 ------
 - Added 3.11. Removed 32-bit wheels.

--- a/src/pydrobert/kaldi/io/command_line.py
+++ b/src/pydrobert/kaldi/io/command_line.py
@@ -128,7 +128,7 @@ def write_table_to_pickle(args: Optional[Sequence[str]] = None) -> None:
         return 1
     num_entries = 0
     try:
-        for key, value in list(reader.items()):
+        for key, value in reader.items():
             num_entries += 1
             if not np.issubdtype(out_type, np.dtype(str).type):
                 value = value.astype(out_type)
@@ -526,7 +526,7 @@ def write_table_to_torch_dir(args: Optional[Sequence[str]] = None) -> None:
     except FileExistsError:
         pass
     with kaldi_open(options.rspecifier, options.in_type) as table:
-        for key, value in list(table.items()):
+        for key, value in table.items():
             value = torch.tensor(value).type(out_type)
             torch.save(
                 value,

--- a/src/pydrobert/kaldi/io/command_line.py
+++ b/src/pydrobert/kaldi/io/command_line.py
@@ -495,7 +495,7 @@ def write_table_to_torch_dir(args: Optional[Sequence[str]] = None) -> None:
             enums.KaldiDataType.Int32VectorVector,
         }:
             out_type = "int"
-        elif options.in_type == enums.KaldiDataType.Boolean:
+        elif options.in_type == enums.KaldiDataType.Bool:
             out_type = "byte"
         else:
             print(
@@ -624,7 +624,7 @@ def write_torch_dir_to_table(args: Optional[Sequence[str]] = None) -> None:
         enums.KaldiDataType.Int32VectorVector,
     }:
         torch_type = torch.int
-    elif options.out_type == enums.KaldiDataType.Boolean:
+    elif options.out_type == enums.KaldiDataType.Bool:
         torch_type = torch.uint8
         is_bool = True
     else:


### PR DESCRIPTION
Found an annoying bug in write-table-to-torch-dir wherein all entries were compiled into a list before being written. This causes a massive amount of memory to be used.

Also, there's no such thing as a KaldiDataType.Bool